### PR TITLE
put dbfile in conf for easy access by play

### DIFF
--- a/api/app/controllers/Helpers.scala
+++ b/api/app/controllers/Helpers.scala
@@ -6,7 +6,7 @@ import io.flow.location.v0.models.Location
 import play.Play
 
 object Helpers {
-  val dbFilePath = Play.application().getFile("data/GeoLite2-City.mmdb").getAbsolutePath
+  val dbFilePath = Play.application().getFile("conf/GeoLite2-City.mmdb").getAbsolutePath
   val geoIp = MaxMindIpGeo(dbFilePath, 1000)
 
   def getByIp(ip: String) = {


### PR DESCRIPTION
To make this easy, for now, place DB file in api/conf, so that when project is "stage"d, the following path resolves in Production:

```
/opt/play/api/target/universal/stage/conf/GeoLite2-City.mmdb 
```

Fixes the following error:
```
Caused by: java.io.FileNotFoundException: /opt/play/api/target/universal/stage/data/GeoLite2-City.mmdb (No such file or directory)
```