### PR TITLE
Mild refactor of existing code and add basic Google lookup

### DIFF
--- a/api/app/controllers/Locations.scala
+++ b/api/app/controllers/Locations.scala
@@ -7,27 +7,15 @@ import io.flow.location.v0.models.json._
 import io.flow.common.v0.models.json._
 
 class Locations extends Controller {
-
   def get(
     address: Option[String],
     ip: Option[String],
     latitude: Option[String],
     longitude: Option[String]
   ) = Action { request =>
-    Helpers.validateRequestParameters(address, latitude, longitude) match {
-      case Some(errors) => UnprocessableEntity(Json.toJson(Validation.errors(errors)))
-      case None =>
-        ip match {
-          case Some(ip) => Helpers.getByIp(ip) match {
-            case Some(ipl) =>
-              Helpers.getLocation(ipl) match {
-                case Left(errors) => UnprocessableEntity(Json.toJson(Validation.errors(errors)))
-                case Right(loc) => Ok(Json.toJson(loc))
-              }
-            case None => UnprocessableEntity(Json.toJson(Validation.error(s"No location found for ip [$ip]")))
-          }
-          case None => UnprocessableEntity(Json.toJson(Validation.error("No valid query string parameters given.  Please provide an [ip]")))
-        }
+    Helpers.getLocation(address, latitude, longitude, ip) match {
+      case Left(errors) => UnprocessableEntity(Json.toJson(Validation.errors(errors)))
+      case Right(location) => Ok(Json.toJson(location))
     }
   }
 }

--- a/api/app/utils/Google.scala
+++ b/api/app/utils/Google.scala
@@ -1,0 +1,149 @@
+package utils
+
+import io.flow.common.v0.models.Address
+import io.flow.reference.Countries
+import io.flow.location.v0.models.Location
+import com.google.maps.{GeoApiContext, GeocodingApi}
+import com.google.maps.model.AddressComponent
+import io.flow.play.util.Config
+
+/**
+  * Mostly copied from: https://github.com/flowcommerce/scrapbook/blob/master/lib/src/main/scala/geo/AddressExploration.scala
+  */
+object Google {
+  val config = play.api.Play.current.injector.instanceOf[Config]
+  val context = new GeoApiContext().setApiKey(config.requiredString("google.api.key"))
+
+  def getLocationByAddress(address: String): Either[Seq[String], Location] = {
+    GeocodingApi.geocode(context, address).await().toList match {
+      case Nil => {
+        Left(Seq(s"No results found in Google for address: [$address]"))
+      }
+      case one :: Nil => {
+        val streetNumber = findAsString(one.addressComponents, Seq(Google.AddressComponentType.StreetNumber))
+        val streetAddress = findAsString(one.addressComponents, Seq(Google.AddressComponentType.StreetAddress, Google.AddressComponentType.Route))
+        val street = Seq(streetNumber, streetAddress).flatten.mkString(" ")
+        val city = findAsString(one.addressComponents, Seq(Google.AddressComponentType.Locality))
+        val postal = findAsString(one.addressComponents, Seq(Google.AddressComponentType.PostalCode))
+
+        val country = findAsString(one.addressComponents, Seq(Google.AddressComponentType.Country)) match {
+          case None => sys.error("Google could not find country from address [$address]")
+          case Some(q) => Countries.find(q) match {
+            case None => sys.error(s"Reference lookup could not find country $q")
+            case Some(c) => Some(c.iso31663)
+          }
+        }
+
+        val adminAreas = Seq(
+          findAsString(one.addressComponents, Seq(Google.AddressComponentType.AdministrativeAreaLevel1)),
+          findAsString(one.addressComponents, Seq(Google.AddressComponentType.AdministrativeAreaLevel2)),
+          findAsString(one.addressComponents, Seq(Google.AddressComponentType.AdministrativeAreaLevel3)),
+          findAsString(one.addressComponents, Seq(Google.AddressComponentType.AdministrativeAreaLevel4)),
+          findAsString(one.addressComponents, Seq(Google.AddressComponentType.AdministrativeAreaLevel5))
+        ).flatten
+
+        val (province, county) = adminAreas match {
+          case Nil => (None, None)
+          case a :: Nil => (Some(a), None)
+          case a :: b :: Nil => (Some(a), Some(b))
+          case a :: b :: more => {
+            // TODO: Investigate what the other pieces are
+            (Some(a), Some(b))
+          }
+        }
+
+        val location = Location(
+          address = Address(
+            text = Some(address),
+            streets = Some(Seq(street)),
+            province = province,
+            city = city,
+            postal = postal,
+            country = country
+          ),
+          latitude = one.geometry.location.lat.toString,
+          longitude = one.geometry.location.lng.toString
+        )
+        Right(location)
+      }
+      case multiple => {
+        Left(Seq(s"Multiple results found for address: [$address]"))
+      }
+    }
+  }
+
+  private def findAsString(components: Seq[AddressComponent], types: Seq[AddressComponentType]): Option[String] = {
+    find(components, types) match {
+      case Nil => None
+      case one :: Nil => Some(one.longName)
+      case multiple => Some(multiple.map(_.longName).mkString(" "))
+    }
+  }
+
+  private def findAsShortString(components: Seq[AddressComponent], types: Seq[AddressComponentType]): Option[String] = {
+    find(components, types) match {
+      case Nil => None
+      case one :: Nil => Some(one.shortName)
+      case multiple => Some(multiple.map(_.shortName).mkString(" "))
+    }
+  }
+
+  private def find(components: Seq[AddressComponent], types: Seq[AddressComponentType]): Seq[AddressComponent] = {
+    components.filter { c =>
+      c.types.map( t => Google.AddressComponentType(t.toString) ).find(types.contains(_)) match {
+        case None => false
+        case Some(_) => true
+      }
+    }
+  }
+
+  sealed trait AddressComponentType
+  object AddressComponentType {
+    case object AdministrativeAreaLevel1 extends AddressComponentType { override def toString() = "administrative_area_level_1" }
+    case object AdministrativeAreaLevel2 extends AddressComponentType { override def toString() = "administrative_area_level_2" }
+    case object AdministrativeAreaLevel3 extends AddressComponentType { override def toString() = "administrative_area_level_3" }
+    case object AdministrativeAreaLevel4 extends AddressComponentType { override def toString() = "administrative_area_level_4" }
+    case object AdministrativeAreaLevel5 extends AddressComponentType { override def toString() = "administrative_area_level_5" }
+    case object AIRPORT extends AddressComponentType { override def toString() = "airport" }
+    case object BUS_STATION extends AddressComponentType { override def toString() = "bus_station" }
+    case object COLLOQUIAL_AREA extends AddressComponentType { override def toString() = "colloquial_area" }
+    case object Country extends AddressComponentType { override def toString() = "country" }
+    case object ESTABLISHMENT extends AddressComponentType { override def toString() = "establishment" }
+    case object FLOOR extends AddressComponentType { override def toString() = "floor" }
+    case object INTERSECTION extends AddressComponentType { override def toString() = "intersection" }
+    case object Locality extends AddressComponentType { override def toString() = "locality" }
+    case object NATURAL_FEATURE extends AddressComponentType { override def toString() = "natural_feature" }
+    case object NEIGHBORHOOD extends AddressComponentType { override def toString() = "neighborhood" }
+    case object PARK extends AddressComponentType { override def toString() = "park" }
+    case object PARKING extends AddressComponentType { override def toString() = "parking" }
+    case object POINT_OF_INTEREST extends AddressComponentType { override def toString() = "point_of_interest" }
+    case object POLITICAL extends AddressComponentType { override def toString() = "political" }
+    case object PostBox extends AddressComponentType { override def toString() = "post_box" }
+    case object PostalCode extends AddressComponentType { override def toString() = "postal_code" }
+    case object PostalCodePrefix extends AddressComponentType { override def toString() = "postal_code_prefix" }
+    case object PostalCodeSuffix extends AddressComponentType { override def toString() = "postal_code_suffix" }
+    case object POSTAL_TOWN extends AddressComponentType { override def toString() = "postal_town" }
+    case object PREMISE extends AddressComponentType { override def toString() = "premise" }
+    case object ROOM extends AddressComponentType { override def toString() = "room" }
+    case object Route extends AddressComponentType { override def toString() = "route" }
+    case object StreetAddress extends AddressComponentType { override def toString() = "street_address" }
+    case object StreetNumber extends AddressComponentType { override def toString() = "street_number" }
+    case object SUBLOCALITY extends AddressComponentType { override def toString() = "sublocality" }
+    case object SUBLOCALITY_LEVEL_1  extends AddressComponentType { override def toString() = "sublocality_level_1" }
+    case object SUBLOCALITY_LEVEL_2  extends AddressComponentType { override def toString() = "sublocality_level_2" }
+    case object SUBLOCALITY_LEVEL_3  extends AddressComponentType { override def toString() = "sublocality_level_3" }
+    case object SUBLOCALITY_LEVEL_4  extends AddressComponentType { override def toString() = "sublocality_level_4" }
+    case object SUBLOCALITY_LEVEL_5  extends AddressComponentType { override def toString() = "sublocality_level_5" }
+    case object SUBPREMISE extends AddressComponentType { override def toString() = "subpremise" }
+    case object TRAIN_STATION extends AddressComponentType { override def toString() = "train_station" }
+    case object TRANSIT_STATION extends AddressComponentType { override def toString() = "transit_station" }
+    case object UNKNOWN extends AddressComponentType { override def toString() = "unknown" }
+
+    val all = Seq(AdministrativeAreaLevel1, AdministrativeAreaLevel2, AdministrativeAreaLevel3, AdministrativeAreaLevel4, AdministrativeAreaLevel5, AIRPORT, BUS_STATION, COLLOQUIAL_AREA, Country, ESTABLISHMENT, FLOOR, INTERSECTION, Locality, NATURAL_FEATURE, NEIGHBORHOOD, PARK, PARKING, POINT_OF_INTEREST, POLITICAL, PostBox, PostalCode, PostalCodePrefix, PostalCodeSuffix, POSTAL_TOWN, PREMISE, ROOM, Route, StreetAddress, StreetNumber, SUBLOCALITY, SUBLOCALITY_LEVEL_1, SUBLOCALITY_LEVEL_2, SUBLOCALITY_LEVEL_3, SUBLOCALITY_LEVEL_4, SUBLOCALITY_LEVEL_5, SUBPREMISE, TRAIN_STATION, TRANSIT_STATION, UNKNOWN)
+    private[this] val byName = all.map(x => x.toString.toLowerCase -> x).toMap
+    def apply(value: String): AddressComponentType = fromString(value).getOrElse(UNKNOWN)
+    def fromString(value: String): Option[AddressComponentType] = byName.get(value.toLowerCase)
+
+  }
+
+}

--- a/api/app/utils/MaxMind.scala
+++ b/api/app/utils/MaxMind.scala
@@ -1,0 +1,64 @@
+package utils
+
+import com.sanoma.cda.geoip.{IpLocation, MaxMindIpGeo}
+import io.flow.common.v0.models.Address
+import io.flow.location.v0.models.Location
+
+case class LatLong(latitude: String, longitude: String)
+
+object MaxMind {
+  import sys.process._
+  import java.net.URL
+  import java.io.File
+  import scala.language.postfixOps
+  new URL("https://s3.amazonaws.com/io.flow.aws-s3-public/location/GeoLite2-City.mmdb") #> new File("GeoLite2-City.mmdb") !!
+
+  val geoIp = MaxMindIpGeo("GeoLite2-City.mmdb", 1000)
+
+  def getByIp(ip: String): Option[IpLocation] = {
+    geoIp.getLocation(ip)
+  }
+
+  def getCountryCode(ipl: IpLocation): Option[String]= {
+    ipl.countryCode match {
+      case Some(country) =>
+        io.flow.reference.Countries.find(country) match {
+          case Some(c) => Some(c.iso31663)
+          case None => None
+        }
+      case None => None
+    }
+  }
+
+  def getLatLong(ipl: IpLocation): Option[LatLong] = {
+    ipl.geoPoint.map { p =>
+      LatLong(
+        latitude = p.latitude.toString,
+        longitude = p.longitude.toString
+      )
+    }
+  }
+
+  def getLocation(ipl: IpLocation): Either[Seq[String], Location] = {
+    MaxMind.getLatLong(ipl) match {
+      case None => {
+        Left(Seq(s"Could not geolocate IP"))
+      }
+
+      case Some(geo) => {
+        Right(
+          Location(
+            Address(
+              city = ipl.city,
+              province = ipl.region,
+              postal = ipl.postalCode,
+              country = MaxMind.getCountryCode(ipl)
+            ),
+            latitude = geo.latitude,
+            longitude = geo.longitude
+          )
+        )
+      }
+    }
+  }
+}

--- a/api/conf/base.conf
+++ b/api/conf/base.conf
@@ -1,6 +1,9 @@
 play.i18n.langs=["en"]
 
+google.api.key=${?GOOGLE_API_KEY}
+
 evolutionplugin=disabled
 play.http.requestHandler="play.http.DefaultHttpRequestHandler"
+play.modules.enabled += "io.flow.play.clients.ConfigModule"
 
 git.version=0.0.1

--- a/api/test/utils/MaxMindSpec.scala
+++ b/api/test/utils/MaxMindSpec.scala
@@ -1,4 +1,4 @@
-package controllers
+package utils
 
 import com.sanoma.cda.geo.Point
 import com.sanoma.cda.geoip.IpLocation
@@ -6,9 +6,9 @@ import io.flow.common.v0.models.Address
 import io.flow.location.v0.models.Location
 import org.scalatestplus.play._
 
-class HelpersSpec extends PlaySpec with OneAppPerSuite {
+class MaxMindSpec extends PlaySpec with OneAppPerSuite {
 
-  "Helpers" should {
+  "MaxMind" should {
     val validIpLocation = IpLocation(
       countryCode = Some("CA"),
       countryName = Some("Canada"),
@@ -28,7 +28,7 @@ class HelpersSpec extends PlaySpec with OneAppPerSuite {
       continent = None)
 
     "return valid latitude/longitude when ipLocation is valid" in {
-      val geo = Helpers.getLatLon(validIpLocation).getOrElse {
+      val geo = MaxMind.getLatLong(validIpLocation).getOrElse {
         sys.error("Failed to resolve known IP")
       }
 
@@ -37,19 +37,19 @@ class HelpersSpec extends PlaySpec with OneAppPerSuite {
     }
 
     "return empty latitude/longitude when ipLocation is invalid" in {
-      Helpers.getLatLon(invalidIpLocation) must be(None)
+      MaxMind.getLatLong(invalidIpLocation) must be(None)
     }
 
     "return valid country 3 character iso code when ipLocation is valid" in {
-      Helpers.getCountryCode(validIpLocation) must equal(Some("CAN"))
+      MaxMind.getCountryCode(validIpLocation) must equal(Some("CAN"))
     }
 
     "return no country code when ipLocation is invalid" in {
-      Helpers.getCountryCode(invalidIpLocation) must equal(None)
+      MaxMind.getCountryCode(invalidIpLocation) must equal(None)
     }
 
     "return valid location when ipLocation is valid" in {
-      Helpers.getLocation(validIpLocation) must equal(
+      MaxMind.getLocation(validIpLocation) must equal(
         Right(Location(Address(None,None,Some("Sparwood"),None,None,Some("CAN")),"49.7333","-114.8853"))
       )
     }

--- a/build.sbt
+++ b/build.sbt
@@ -32,7 +32,8 @@ lazy val api = project
       "io.flow" %% "lib-play" % "0.1.17",
       "io.flow" %% "lib-reference" % "0.0.48",
       "org.scalatestplus" %% "play" % "1.4.0" % "test",
-      "com.sanoma.cda" %% "maxmind-geoip2-scala" % "1.5.1"
+      "com.sanoma.cda" %% "maxmind-geoip2-scala" % "1.5.1",
+      "com.google.maps" % "google-maps-services" % "0.1.12"
     )
   )
 


### PR DESCRIPTION
- Controller now just calls the helper
- Helper can take either ip or address (full text string), but not both for now
- Add simple implementation of Google API based on https://github.com/flowcommerce/scrapbook/blob/master/lib/src/main/scala/geo/AddressExploration.scala
- Sample local output:

```
[paolo 10:11:38 /web/location]> curl "http://localhost:9000/locations?address=2+park+ave+ny"
{"address":{"text":"2 park ave ny","streets":["2 Park Avenue"],"city":"New York","province":"New York","postal":"10016","country":"USA"},"latitude":"40.7463331","longitude":"-73.9825954"}

[paolo 10:11:44 /web/location]> curl "http://localhost:9000/locations?address=12+downing+street+london"
{"address":{"text":"12 downing street london","streets":["12 Downing Street"],"city":"London","province":"Greater London","postal":"SW1A","country":"GBR"},"latitude":"51.5033045","longitude":"-0.1279018"}

[paolo 10:11:46 /web/location]> curl "http://localhost:9000/locations?address=22+Hudson+Place+Hoboken+NJ+USA"
{"address":{"text":"22 Hudson Place Hoboken NJ USA","streets":["22 Hudson Place"],"city":"Hoboken","province":"New Jersey","postal":"07030","country":"USA"},"latitude":"40.7361043","longitude":"-74.0288937"}
```