### PR TITLE
Add ability to recognize an address as a country code

### DIFF
--- a/api/app/controllers/Helpers.scala
+++ b/api/app/controllers/Helpers.scala
@@ -1,6 +1,8 @@
 package controllers
 
+import io.flow.common.v0.models.Address
 import io.flow.location.v0.models.Location
+import io.flow.reference.Countries
 import utils._
 
 object Helpers {
@@ -48,7 +50,26 @@ object Helpers {
               case None => Left(Seq("No location found for ip [$ip]"))
             }
           }
-          case (None, Some(a)) => Google.getLocationsByAddress(a)
+          case (None, Some(a)) => {
+            // Special case to enable specifying just a country code in the address line
+            Countries.find(a) match {
+              case Some(c) => {
+                Right(
+                  Seq(
+                    Location(
+                      address = Address(country = Some(c.iso31663)),
+                      latitude = "0",
+                      longitude = "0"
+                    )
+                  )
+                )
+              }
+
+              case None => {
+                Google.getLocationsByAddress(a)
+              }
+            }
+          }
           case _ => Left(Seq("Invalid input. Either use ip or address, not both.")) // limitation for now, we can clean up later
         }
       }


### PR DESCRIPTION
- I saw that geo locating an address like 'CAN' resulted in an address
   from google in Turkey
 - This change adds support to recognize a country directly - and if found,
   returns an address with only the country specified
 - Note that in this case we don't have a lat/long and thus they are defaulted
   to zero in this PR. We may want to consider making lat/long optional in a
   future PR