### PR TITLE
Use t2.medium since aws has c4.large errors

### DIFF
--- a/.delta
+++ b/.delta
@@ -1,6 +1,6 @@
 builds:
   - root:
-      instance.type: c4.large
+      instance.type: t2.medium
       port.container: 9000
       port.host: 6191
       memory: 3500


### PR DESCRIPTION
Getting the following issue with AWS, so just pick something else for now:

<img width="975" alt="screen shot 2016-12-05 at 11 15 31 pm" src="https://cloud.githubusercontent.com/assets/85070/20912856/e5cd0c70-bb40-11e6-808c-4ad41c3e659e.png">
