### PR TITLE
handle the cases where ipv4 addresses are mapped to ipv6 space.

### DIFF
--- a/api/app/utils/DigitalElement.scala
+++ b/api/app/utils/DigitalElement.scala
@@ -50,7 +50,7 @@ case class DigitalElementIndexRecord(
 
 object DigitalElement {
 
-  private[this] val ipv4 = "(\\d+)\\.(\\d+)\\.(\\d+)\\.(\\d+)".r
+  private[this] val ipv4 = "(?:::ffff:)?(\\d+)\\.(\\d+)\\.(\\d+)\\.(\\d+)".r
   // digitalelement separates the network and interface portions of ipv6
   // so we only care about the first 4 groups
   private[this] val ipv6 = "([a-fA-F0-9]*):([a-fA-F0-9]*):([a-fA-F0-9]*):([a-fA-F0-9]*)((:[a-fA-F0-9]*){4})".r

--- a/api/test/utils/DigitalElementSpec.scala
+++ b/api/test/utils/DigitalElementSpec.scala
@@ -32,6 +32,7 @@ class DigitalElementSpec extends WordSpec with Matchers {
       DigitalElement.ipToDecimal("0.0.0.0") should be(Success(BigInt("0")))
       DigitalElement.ipToDecimal("192.168.1.1") should be(Success(BigInt("3232235777")))
       DigitalElement.ipToDecimal("255.255.255.255") should be(Success(BigInt("4294967295")))
+      DigitalElement.ipToDecimal("::ffff:255.255.255.255") should be(Success(BigInt("4294967295")))
     }
 
     "correctly Convert ip6 addresses" in {


### PR DESCRIPTION
will stop errors like this in session:
```{"log":"io.flow.location.v0.errors.GenericErrorResponse: 422: {\"code\":\"generic_error\",\"messages\":[\"Unable to parse ip address ::ffff:10.242.166.107\"]}","stream":"stdout","time":"2017-07-20T05:28:00.493912825Z"}```