### PR TITLE
Connection timeout

### DIFF
--- a/api/app/utils/Google.scala
+++ b/api/app/utils/Google.scala
@@ -76,6 +76,7 @@ class Google @javax.inject.Inject() (
 ) {
 
   private[this] val context = new GeoApiContext.Builder()
+    .connectTimeout(1000, TimeUnit.MILLISECONDS)
     .readTimeout(1000, TimeUnit.MILLISECONDS)
     .apiKey(environmentVariables.googleApiKey)
     .build()

--- a/api/app/utils/Google.scala
+++ b/api/app/utils/Google.scala
@@ -2,12 +2,14 @@ package utils
 
 
 import java.util.concurrent.TimeUnit
+
 import akka.actor.ActorSystem
 import com.google.maps.{GeoApiContext, GeocodingApi, TimeZoneApi}
 import com.google.maps.model.{AddressComponent, GeocodingResult, LatLng}
 import io.flow.reference.{Countries, Timezones}
 import io.flow.common.v0.models.Address
 import io.flow.reference.v0.models.Timezone
+import org.apache.commons.lang3.exception.ExceptionUtils
 import play.api.Logger
 
 import scala.concurrent.Future
@@ -92,7 +94,7 @@ class Google @javax.inject.Inject() (
       } match {
         case Success(result) => result
         case Failure(e) => {
-          Logger.warn(s"Encountered the following error from the timezone API: $e")
+          Logger.warn(s"Encountered the following error from the timezone API: ${ExceptionUtils.getStackTrace(e)}")
           None
         }
       }


### PR DESCRIPTION
Intended to help resolve and print full stack trace for:
```
{"log":"[\u001b[37minfo\u001b[0m] application - GET location.api.flow.io/addresses?address=Milan%2BMI%2BItaly 200 1066ms  apibuilder:0.12.52 https://app.apibuilder.io/flow/location/0.3.47/play_2_4_client 52.86.80.125 \n","stream":"stdout","time":"2017-09-25T20:29:31.235907331Z"}
```

We've received 900 of these errors in the last 7 days and it also fails in `scrapbook` sometimes.