### PR TITLE
Upgrade libraries: com.amazonaws, com.google.maps

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -31,8 +31,8 @@ lazy val api = project
       "org.scalatestplus" %% "play" % "1.4.0" % "test",
       "org.scalacheck" %% "scalacheck" % "1.13.5" % "test",
       "com.sanoma.cda" %% "maxmind-geoip2-scala" % "1.5.1",
-      "com.google.maps" % "google-maps-services" % "0.2.3",
-      "com.amazonaws" % "aws-java-sdk-s3" % "1.11.209"
+      "com.google.maps" % "google-maps-services" % "0.2.4",
+      "com.amazonaws" % "aws-java-sdk-s3" % "1.11.210"
     )
   )
 


### PR DESCRIPTION
- com.amazonaws
    - aws-java-sdk-s3 (1.11.209 => 1.11.210)
  - com.google.maps
    - google-maps-services (0.2.3 => 0.2.4)