### PR TITLE
Upgrade libraries: io.flow

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -26,15 +26,15 @@ lazy val api = project
     routesImport += "io.flow.location.v0.Bindables._",
     routesGenerator := InjectedRoutesGenerator,
     libraryDependencies ++= Seq(
-      "io.flow" %% "lib-play-play26" % "0.5.25",
-      "io.flow" %% "lib-play-graphite-play26" % "0.0.63",
+      "io.flow" %% "lib-play-play26" % "0.5.28",
+      "io.flow" %% "lib-play-graphite-play26" % "0.0.71",
       "io.flow" %% "lib-reference-scala" % "0.2.19",
-      "io.flow" %% "lib-s3-play26" % "0.2.31",
+      "io.flow" %% "lib-s3-play26" % "0.2.41",
       "com.google.maps" % "google-maps-services" % "0.9.1",
       "org.scalacheck" %% "scalacheck" % "1.14.0" % "test",
-      "io.flow" %% "lib-test-utils" % "0.0.26" % Test,
-      "io.flow" %% "lib-usage" % "0.0.53",
-      "io.flow" %% "lib-log" % "0.0.52"
+      "io.flow" %% "lib-test-utils" % "0.0.29" % Test,
+      "io.flow" %% "lib-usage" % "0.0.64",
+      "io.flow" %% "lib-log" % "0.0.54"
     )
   )
 


### PR DESCRIPTION
- io.flow
  - lib-log (0.0.52 => 0.0.54)
  - lib-play-graphite-play26 (0.0.63 => 0.0.71)
  - lib-play-play26 (0.5.25 => 0.5.28)
  - lib-s3-play26 (0.2.31 => 0.2.41)
  - lib-test-utils (0.0.26 => 0.0.29)
  - lib-usage (0.0.53 => 0.0.64)
