### PR TITLE
dont aggregate projects

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,6 @@ lazy val generated = project
 lazy val api = project
   .in(file("api"))
   .dependsOn(generated)
-  .aggregate(generated)
   .enablePlugins(PlayScala)
   .enablePlugins(NewRelic)
   .enablePlugins(JavaAppPackaging, JavaAgent)


### PR DESCRIPTION
Aggregation means that tasks run on `api` will also be run on `generated`. I'm running my linter (https://github.com/flowcommerce/sbt-flow-linter) with `api/flowLint`, which runs `generated/flowLint` because of aggregation, but linting the generated files does not make sense and causes errors. We can disable aggregation just for `flowLint` specifically, but I don't think its needed for any task.