### PR TITLE
Update to latest lib-play-graphite

### DIFF
--- a/api/conf/application.production.conf
+++ b/api/conf/application.production.conf
@@ -1,4 +1,5 @@
 include "base.conf"
+include "/flow-metrics.conf"
 
 digitalelement.file.uri = ${DIGITALELEMENT_FILE_URI}
 

--- a/api/conf/base.conf
+++ b/api/conf/base.conf
@@ -6,15 +6,7 @@ evolutionplugin = "disabled"
 
 google.api.key = ${?GOOGLE_API_KEY}
 
-graphite.api.host = ${?CONF_GRAPHITE_API_HOST}
-graphite.api.key = ${?CONF_GRAPHITE_API_KEY}
-graphite.api.port = ${?CONF_GRAPHITE_API_PORT_PICKLE}
 
-kamon.graphite.hostname = ${?CONF_GRAPHITE_API_HOST}
-kamon.graphite.key = ${?CONF_GRAPHITE_API_KEY}
-kamon.graphite.metric-key-generator = "io.flow.play.metrics.kamon.MetricKeyGenerator"
-kamon.graphite.percentiles = [90, 99]
-kamon.graphite.port = ${?CONF_GRAPHITE_API_PORT}
 
 play.filters.disabled += "play.filters.hosts.AllowedHostsFilter"
 

--- a/build.sbt
+++ b/build.sbt
@@ -28,7 +28,7 @@ lazy val api = project
     routesGenerator := InjectedRoutesGenerator,
     libraryDependencies ++= Seq(
       "io.flow" %% "lib-play-play26" % "0.5.69",
-      "io.flow" %% "lib-play-graphite-play26" % "0.1.19",
+      "io.flow" %% "lib-play-graphite-play26" % "0.1.18",
       "io.flow" %% "lib-reference-scala" % "0.2.31",
       "io.flow" %% "lib-s3-play26" % "0.2.67",
       "com.google.maps" % "google-maps-services" % "0.9.1",

--- a/build.sbt
+++ b/build.sbt
@@ -22,16 +22,13 @@ lazy val api = project
   .enablePlugins(JavaAppPackaging, JavaAgent)
   .settings(commonSettings: _*)
   .settings(
-    javaAgents += "org.aspectj" % "aspectjweaver" % "1.9.2",
-    javaOptions in Universal += "-Dorg.aspectj.tracing.factory=default",
-    javaOptions in Test += "-Dkamon.modules.kamon-system-metrics.auto-start=false",
-    javaOptions in Test += "-Dkamon.show-aspectj-missing-warning=no",
+    javaAgents += "io.kamon" % "kanela-agent" % "1.0.2",
     javaOptions in Test += "-Dconfig.file=conf/application.test.conf",
     routesImport += "io.flow.location.v0.Bindables._",
     routesGenerator := InjectedRoutesGenerator,
     libraryDependencies ++= Seq(
       "io.flow" %% "lib-play-play26" % "0.5.69",
-      "io.flow" %% "lib-play-graphite-play26" % "0.1.0",
+      "io.flow" %% "lib-play-graphite-play26" % "0.1.19",
       "io.flow" %% "lib-reference-scala" % "0.2.31",
       "io.flow" %% "lib-s3-play26" % "0.2.67",
       "com.google.maps" % "google-maps-services" % "0.9.1",


### PR DESCRIPTION
This upgrades the Kamon (https://kamon.io) metric library to version 2.0.