### PR TITLE
Upgrade libraries io.flow

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -35,15 +35,15 @@ lazy val api = project
     routesImport += "io.flow.location.v0.Bindables._",
     routesGenerator := InjectedRoutesGenerator,
     libraryDependencies ++= Seq(
-      "io.flow" %% "lib-play-play28" % "0.7.0",
-      "io.flow" %% "lib-metrics-play28" % "1.0.6",
-      "io.flow" %% "lib-reference-scala" % "0.2.91",
-      "io.flow" %% "lib-s3-play28" % "0.3.36",
+      "io.flow" %% "lib-play-play28" % "0.7.2",
+      "io.flow" %% "lib-metrics-play28" % "1.0.8",
+      "io.flow" %% "lib-reference-scala" % "0.2.92",
+      "io.flow" %% "lib-s3-play28" % "0.3.37",
       "com.google.maps" % "google-maps-services" % "1.0.0",
       "org.scalacheck" %% "scalacheck" % "1.15.4" % "test",
-      "io.flow" %% "lib-test-utils-play28" % "0.1.48" % Test,
-      "io.flow" %% "lib-usage-play28" % "0.1.75",
-      "io.flow" %% "lib-log" % "0.1.49"
+      "io.flow" %% "lib-test-utils-play28" % "0.1.50" % Test,
+      "io.flow" %% "lib-usage-play28" % "0.1.77",
+      "io.flow" %% "lib-log" % "0.1.51"
     ),
   )
 


### PR DESCRIPTION
- io.flow
  - lib-log (0.1.49 => 0.1.51)
  - lib-metrics-play28 (1.0.6 => 1.0.8)
  - lib-play-play28 (0.7.0 => 0.7.2)
  - lib-reference-scala (0.2.91 => 0.2.92)
  - lib-s3-play28 (0.3.36 => 0.3.37)
  - lib-test-utils-play28 (0.1.48 => 0.1.50)
  - lib-usage-play28 (0.1.75 => 0.1.77)