### PR TITLE
Upgrade libraries com.typesafe.play, io.flow

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -35,15 +35,15 @@ lazy val api = project
     routesImport += "io.flow.location.v0.Bindables._",
     routesGenerator := InjectedRoutesGenerator,
     libraryDependencies ++= Seq(
-      "io.flow" %% "lib-play-play28" % "0.7.13",
-      "io.flow" %% "lib-metrics-play28" % "1.0.16",
-      "io.flow" %% "lib-reference-scala" % "0.2.93",
-      "io.flow" %% "lib-s3-play28" % "0.3.42",
+      "io.flow" %% "lib-play-play28" % "0.7.18",
+      "io.flow" %% "lib-metrics-play28" % "1.0.19",
+      "io.flow" %% "lib-reference-scala" % "0.2.96",
+      "io.flow" %% "lib-s3-play28" % "0.3.44",
       "com.google.maps" % "google-maps-services" % "1.0.1",
       "org.scalacheck" %% "scalacheck" % "1.15.4" % "test",
-      "io.flow" %% "lib-test-utils-play28" % "0.1.62" % Test,
-      "io.flow" %% "lib-usage-play28" % "0.1.84",
-      "io.flow" %% "lib-log" % "0.1.59"
+      "io.flow" %% "lib-test-utils-play28" % "0.1.64" % Test,
+      "io.flow" %% "lib-usage-play28" % "0.1.85",
+      "io.flow" %% "lib-log" % "0.1.61"
     ),
   )
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,7 +5,7 @@ logLevel := Level.Warn
 resolvers += "Typesafe repository" at "https://repo.typesafe.com/typesafe/releases/"
 
 // Use the Play sbt plugin for Play projects
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.11")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.13")
 
 addSbtPlugin("com.lightbend.sbt" % "sbt-javaagent" % "0.1.5")
 
@@ -15,4 +15,4 @@ addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.1.20")
 
 resolvers += "Flow Plugins" at "https://flow.jfrog.io/flow/plugins-release/"
 
-addSbtPlugin("io.flow" % "sbt-flow-linter" % "0.0.33")
+addSbtPlugin("io.flow" % "sbt-flow-linter" % "0.0.34")


### PR DESCRIPTION
- com.typesafe.play
  - sbt-plugin (2.8.11 => 2.8.13)
- io.flow
  - lib-log (0.1.59 => 0.1.61)
  - lib-metrics-play28 (1.0.16 => 1.0.19)
  - lib-play-play28 (0.7.13 => 0.7.18)
  - lib-reference-scala (0.2.93 => 0.2.96)
  - lib-s3-play28 (0.3.42 => 0.3.44)
  - lib-test-utils-play28 (0.1.62 => 0.1.64)
  - lib-usage-play28 (0.1.84 => 0.1.85)
  - sbt-flow-linter (0.0.33 => 0.0.34)