### PR TITLE
Upgrade libraries com.datadoghq, io.flow

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -30,20 +30,20 @@ lazy val api = project
   .enablePlugins(JavaAppPackaging, JavaAgent)
   .settings(commonSettings: _*)
   .settings(
-    javaAgents += "com.datadoghq" % "dd-java-agent" % "0.95.1",
+    javaAgents += "com.datadoghq" % "dd-java-agent" % "0.97.0",
     Test / javaOptions += "-Dconfig.file=conf/application.test.conf",
     routesImport += "io.flow.location.v0.Bindables._",
     routesGenerator := InjectedRoutesGenerator,
     libraryDependencies ++= Seq(
-      "io.flow" %% "lib-play-play28" % "0.7.24",
-      "io.flow" %% "lib-metrics-play28" % "1.0.22",
-      "io.flow" %% "lib-reference-scala" % "0.2.99",
-      "io.flow" %% "lib-s3-play28" % "0.3.47",
+      "io.flow" %% "lib-play-play28" % "0.7.26",
+      "io.flow" %% "lib-metrics-play28" % "1.0.24",
+      "io.flow" %% "lib-reference-scala" % "0.3.0",
+      "io.flow" %% "lib-s3-play28" % "0.3.48",
       "com.google.maps" % "google-maps-services" % "2.0.0",
       "org.scalacheck" %% "scalacheck" % "1.15.4" % "test",
-      "io.flow" %% "lib-test-utils-play28" % "0.1.68" % Test,
-      "io.flow" %% "lib-usage-play28" % "0.1.88",
-      "io.flow" %% "lib-log" % "0.1.64"
+      "io.flow" %% "lib-test-utils-play28" % "0.1.69" % Test,
+      "io.flow" %% "lib-usage-play28" % "0.1.89",
+      "io.flow" %% "lib-log" % "0.1.65"
     ),
   )
 


### PR DESCRIPTION
- com.datadoghq
  - dd-java-agent (0.95.1 => 0.97.0)
- io.flow
  - lib-log (0.1.64 => 0.1.65)
  - lib-metrics-play28 (1.0.22 => 1.0.24)
  - lib-play-play28 (0.7.24 => 0.7.26)
  - lib-reference-scala (0.2.99 => 0.3.0)
  - lib-s3-play28 (0.3.47 => 0.3.48)
  - lib-test-utils-play28 (0.1.68 => 0.1.69)
  - lib-usage-play28 (0.1.88 => 0.1.89)