### PR TITLE
Upgrade libraries

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -30,20 +30,20 @@ lazy val api = project
   .enablePlugins(JavaAppPackaging, JavaAgent)
   .settings(commonSettings: _*)
   .settings(
-    javaAgents += "com.datadoghq" % "dd-java-agent" % "0.104.0",
+    javaAgents += "com.datadoghq" % "dd-java-agent" % "0.108.2",
     Test / javaOptions += "-Dconfig.file=conf/application.test.conf",
     routesImport += "io.flow.location.v0.Bindables._",
     routesGenerator := InjectedRoutesGenerator,
     libraryDependencies ++= Seq(
-      "io.flow" %% "lib-play-play28" % "0.7.35",
-      "io.flow" %% "lib-metrics-play28" % "1.0.32",
-      "io.flow" %% "lib-reference-scala" % "0.3.5",
-      "io.flow" %% "lib-s3-play28" % "0.3.54",
-      "com.google.maps" % "google-maps-services" % "2.0.0",
-      "org.scalacheck" %% "scalacheck" % "1.16.0" % "test",
-      "io.flow" %% "lib-test-utils-play28" % "0.1.78" % Test,
-      "io.flow" %% "lib-usage-play28" % "0.1.95",
-      "io.flow" %% "lib-log" % "0.1.71"
+      "io.flow" %% "lib-play-play28" % "0.7.41",
+      "io.flow" %% "lib-metrics-play28" % "1.0.33",
+      "io.flow" %% "lib-reference-scala" % "0.3.6",
+      "io.flow" %% "lib-s3-play28" % "0.3.55",
+      "com.google.maps" % "google-maps-services" % "2.1.0",
+      "org.scalacheck" %% "scalacheck" % "1.17.0" % "test",
+      "io.flow" %% "lib-test-utils-play28" % "0.1.79" % Test,
+      "io.flow" %% "lib-usage-play28" % "0.1.96",
+      "io.flow" %% "lib-log" % "0.1.73"
     ),
   )
 
@@ -52,8 +52,8 @@ lazy val commonSettings: Seq[Setting[_]] = Seq(
   libraryDependencies ++= Seq(
     guice,
     ws,
-    "com.typesafe.play" %% "play-json-joda" % "2.9.2",
-    "com.typesafe.play" %% "play-json" % "2.9.2",
+    "com.typesafe.play" %% "play-json-joda" % "2.9.3",
+    "com.typesafe.play" %% "play-json" % "2.9.3",
   ),
   scalacOptions ++= allScalacOptions,
   resolvers += "scalaz-bintray" at "https://dl.bintray.com/scalaz/releases",


### PR DESCRIPTION
- com.datadoghq
  - dd-java-agent (0.104.0 => 0.108.2)
- com.google.maps
  - google-maps-services (2.0.0 => 2.1.0)
- com.typesafe.play
  - play-json (2.9.2 => 2.9.3)
  - play-json-joda (2.9.2 => 2.9.3)
- io.flow
  - lib-log (0.1.71 => 0.1.73)
  - lib-metrics-play28 (1.0.32 => 1.0.33)
  - lib-play-play28 (0.7.35 => 0.7.41)
  - lib-reference-scala (0.3.5 => 0.3.6)
  - lib-s3-play28 (0.3.54 => 0.3.55)
  - lib-test-utils-play28 (0.1.78 => 0.1.79)
  - lib-usage-play28 (0.1.95 => 0.1.96)
- org.scalacheck
  - scalacheck (1.16.0 => 1.17.0)