### PR TITLE
Upgrade libraries com.datadoghq, io.flow

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -30,21 +30,21 @@ lazy val api = project
   .enablePlugins(JavaAppPackaging, JavaAgent)
   .settings(commonSettings: _*)
   .settings(
-    javaAgents += "com.datadoghq" % "dd-java-agent" % "1.2.0",
+    javaAgents += "com.datadoghq" % "dd-java-agent" % "1.3.0",
     Test / javaOptions += "-Dconfig.file=conf/application.test.conf",
     routesImport += "io.flow.location.v0.Bindables._",
     routesGenerator := InjectedRoutesGenerator,
     libraryDependencies ++= Seq(
-      "io.flow" %% "lib-play-play28" % "0.7.51",
-      "io.flow" %% "lib-metrics-play28" % "1.0.41",
-      "io.flow" %% "lib-reference-scala" % "0.3.10",
-      "io.flow" %% "lib-s3-play28" % "0.3.62",
+      "io.flow" %% "lib-play-play28" % "0.7.54",
+      "io.flow" %% "lib-metrics-play28" % "1.0.45",
+      "io.flow" %% "lib-reference-scala" % "0.3.13",
+      "io.flow" %% "lib-s3-play28" % "0.3.66",
       "com.google.maps" % "google-maps-services" % "2.0.0",
-      "io.flow" %% "lib-healthcheck-play28" % "0.0.2",
+      "io.flow" %% "lib-healthcheck-play28" % "0.0.4",
       "org.scalacheck" %% "scalacheck" % "1.17.0" % "test",
-      "io.flow" %% "lib-test-utils-play28" % "0.1.86" % Test,
-      "io.flow" %% "lib-usage-play28" % "0.2.5",
-      "io.flow" %% "lib-log" % "0.1.80"
+      "io.flow" %% "lib-test-utils-play28" % "0.1.90" % Test,
+      "io.flow" %% "lib-usage-play28" % "0.2.7",
+      "io.flow" %% "lib-log" % "0.1.83"
     ),
   )
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -15,7 +15,7 @@ addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.4.1")
 
 resolvers += "Flow Plugins" at "https://flow.jfrog.io/flow/plugins-release/"
 
-addSbtPlugin("io.flow" % "sbt-flow-linter" % "0.0.34")
+addSbtPlugin("io.flow" % "sbt-flow-linter" % "0.0.35")
 
 // Resolve scala-xml version dependency mismatch, see https://github.com/sbt/sbt/issues/7007
 ThisBuild / libraryDependencySchemes ++= Seq(


### PR DESCRIPTION
- com.datadoghq
  - dd-java-agent (1.2.0 => 1.3.0)
- io.flow
  - lib-healthcheck-play28 (0.0.2 => 0.0.4)
  - lib-log (0.1.80 => 0.1.83)
  - lib-metrics-play28 (1.0.41 => 1.0.45)
  - lib-play-play28 (0.7.51 => 0.7.54)
  - lib-reference-scala (0.3.10 => 0.3.13)
  - lib-s3-play28 (0.3.62 => 0.3.66)
  - lib-test-utils-play28 (0.1.86 => 0.1.90)
  - lib-usage-play28 (0.2.5 => 0.2.7)
  - sbt-flow-linter (0.0.34 => 0.0.35)