### PR TITLE
Upgrade libraries com.datadoghq, io.flow

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -31,20 +31,20 @@ lazy val api = project
   .enablePlugins(JavaAppPackaging, JavaAgent)
   .settings(commonSettings: _*)
   .settings(
-    javaAgents += "com.datadoghq" % "dd-java-agent" % "1.12.1",
+    javaAgents += "com.datadoghq" % "dd-java-agent" % "1.13.0",
     Test / javaOptions += "-Dconfig.file=conf/application.test.conf",
     routesImport += "io.flow.location.v0.Bindables._",
     routesGenerator := InjectedRoutesGenerator,
     libraryDependencies ++= Seq(
-      "io.flow" %% "lib-play-play28" % "0.7.63",
-      "io.flow" %% "lib-metrics-play28" % "1.0.51",
-      "io.flow" %% "lib-reference-scala" % "0.3.16",
-      "io.flow" %% "lib-s3-play28" % "0.3.72",
+      "io.flow" %% "lib-play-play28" % "0.7.64",
+      "io.flow" %% "lib-metrics-play28" % "1.0.52",
+      "io.flow" %% "lib-reference-scala" % "0.3.20",
+      "io.flow" %% "lib-s3-play28" % "0.3.73",
       "com.google.maps" % "google-maps-services" % "2.0.0",
       "io.flow" %% "lib-healthcheck-play28" % "0.0.11",
       "org.scalacheck" %% "scalacheck" % "1.17.0" % "test",
-      "io.flow" %% "lib-test-utils-play28" % "0.1.96" % Test,
-      "io.flow" %% "lib-usage-play28" % "0.2.15",
+      "io.flow" %% "lib-test-utils-play28" % "0.1.97" % Test,
+      "io.flow" %% "lib-usage-play28" % "0.2.16",
       "io.flow" %% "lib-log" % "0.1.92"
     ),
   )


### PR DESCRIPTION
- com.datadoghq
  - dd-java-agent (1.12.1 => 1.13.0)
- io.flow
  - lib-metrics-play28 (1.0.51 => 1.0.52)
  - lib-play-play28 (0.7.63 => 0.7.64)
  - lib-reference-scala (0.3.16 => 0.3.20)
  - lib-s3-play28 (0.3.72 => 0.3.73)
  - lib-test-utils-play28 (0.1.96 => 0.1.97)
  - lib-usage-play28 (0.2.15 => 0.2.16)