### PR TITLE
Upgrade libraries com.datadoghq, io.flow

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -31,21 +31,21 @@ lazy val api = project
   .enablePlugins(JavaAppPackaging, JavaAgent)
   .settings(commonSettings: _*)
   .settings(
-    javaAgents += "com.datadoghq" % "dd-java-agent" % "1.13.0",
+    javaAgents += "com.datadoghq" % "dd-java-agent" % "1.14.0",
     Test / javaOptions += "-Dconfig.file=conf/application.test.conf",
     routesImport += "io.flow.location.v0.Bindables._",
     routesGenerator := InjectedRoutesGenerator,
     libraryDependencies ++= Seq(
-      "io.flow" %% "lib-play-play28" % "0.7.64",
-      "io.flow" %% "lib-metrics-play28" % "1.0.52",
-      "io.flow" %% "lib-reference-scala" % "0.3.20",
-      "io.flow" %% "lib-s3-play28" % "0.3.73",
+      "io.flow" %% "lib-play-play28" % "0.7.68",
+      "io.flow" %% "lib-metrics-play28" % "1.0.54",
+      "io.flow" %% "lib-reference-scala" % "0.3.22",
+      "io.flow" %% "lib-s3-play28" % "0.3.75",
       "com.google.maps" % "google-maps-services" % "2.0.0",
-      "io.flow" %% "lib-healthcheck-play28" % "0.0.11",
+      "io.flow" %% "lib-healthcheck-play28" % "0.0.12",
       "org.scalacheck" %% "scalacheck" % "1.17.0" % "test",
-      "io.flow" %% "lib-test-utils-play28" % "0.1.97" % Test,
-      "io.flow" %% "lib-usage-play28" % "0.2.16",
-      "io.flow" %% "lib-log" % "0.1.92"
+      "io.flow" %% "lib-test-utils-play28" % "0.1.99" % Test,
+      "io.flow" %% "lib-usage-play28" % "0.2.18",
+      "io.flow" %% "lib-log" % "0.1.94"
     ),
   )
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -15,7 +15,7 @@ addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.4.1")
 
 resolvers += "Flow Plugins" at "https://flow.jfrog.io/flow/plugins-release/"
 
-addSbtPlugin("io.flow" % "sbt-flow-linter" % "0.0.36")
+addSbtPlugin("io.flow" % "sbt-flow-linter" % "0.0.37")
 
 // Resolve scala-xml version dependency mismatch, see https://github.com/sbt/sbt/issues/7007
 ThisBuild / libraryDependencySchemes ++= Seq(


### PR DESCRIPTION
- com.datadoghq
  - dd-java-agent (1.13.0 => 1.14.0)
- io.flow
  - lib-healthcheck-play28 (0.0.11 => 0.0.12)
  - lib-log (0.1.92 => 0.1.94)
  - lib-metrics-play28 (1.0.52 => 1.0.54)
  - lib-play-play28 (0.7.64 => 0.7.68)
  - lib-reference-scala (0.3.20 => 0.3.22)
  - lib-s3-play28 (0.3.73 => 0.3.75)
  - lib-test-utils-play28 (0.1.97 => 0.1.99)
  - lib-usage-play28 (0.2.16 => 0.2.18)
  - sbt-flow-linter (0.0.36 => 0.0.37)