### PR TITLE
Upgrade libraries com.datadoghq, io.flow

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -31,21 +31,21 @@ lazy val api = project
   .enablePlugins(JavaAppPackaging, JavaAgent)
   .settings(commonSettings: _*)
   .settings(
-    javaAgents += "com.datadoghq" % "dd-java-agent" % "1.14.0",
+    javaAgents += "com.datadoghq" % "dd-java-agent" % "1.15.3",
     Test / javaOptions += "-Dconfig.file=conf/application.test.conf",
     routesImport += "io.flow.location.v0.Bindables._",
     routesGenerator := InjectedRoutesGenerator,
     libraryDependencies ++= Seq(
-      "io.flow" %% "lib-play-play28" % "0.7.69",
-      "io.flow" %% "lib-metrics-play28" % "1.0.55",
-      "io.flow" %% "lib-reference-scala" % "0.3.22",
-      "io.flow" %% "lib-s3-play28" % "0.3.76",
+      "io.flow" %% "lib-play-play28" % "0.7.71",
+      "io.flow" %% "lib-metrics-play28" % "1.0.57",
+      "io.flow" %% "lib-reference-scala" % "0.3.23",
+      "io.flow" %% "lib-s3-play28" % "0.3.77",
       "com.google.maps" % "google-maps-services" % "2.0.0",
       "io.flow" %% "lib-healthcheck-play28" % "0.0.12",
       "org.scalacheck" %% "scalacheck" % "1.17.0" % "test",
-      "io.flow" %% "lib-test-utils-play28" % "0.2.0" % Test,
-      "io.flow" %% "lib-usage-play28" % "0.2.20",
-      "io.flow" %% "lib-log" % "0.1.94"
+      "io.flow" %% "lib-test-utils-play28" % "0.2.1" % Test,
+      "io.flow" %% "lib-usage-play28" % "0.2.22",
+      "io.flow" %% "lib-log" % "0.1.95"
     ),
   )
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -15,7 +15,7 @@ addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.4.1")
 
 resolvers += "Flow Plugins" at "https://flow.jfrog.io/flow/plugins-release/"
 
-addSbtPlugin("io.flow" % "sbt-flow-linter" % "0.0.37")
+addSbtPlugin("io.flow" % "sbt-flow-linter" % "0.0.38")
 
 // Resolve scala-xml version dependency mismatch, see https://github.com/sbt/sbt/issues/7007
 ThisBuild / libraryDependencySchemes ++= Seq(


### PR DESCRIPTION
- com.datadoghq
  - dd-java-agent (1.14.0 => 1.15.3)
- io.flow
  - lib-log (0.1.94 => 0.1.95)
  - lib-metrics-play28 (1.0.55 => 1.0.57)
  - lib-play-play28 (0.7.69 => 0.7.71)
  - lib-reference-scala (0.3.22 => 0.3.23)
  - lib-s3-play28 (0.3.76 => 0.3.77)
  - lib-test-utils-play28 (0.2.0 => 0.2.1)
  - lib-usage-play28 (0.2.20 => 0.2.22)
  - sbt-flow-linter (0.0.37 => 0.0.38)