### PR TITLE
Upgrade libraries

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -31,21 +31,21 @@ lazy val api = project
   .enablePlugins(JavaAppPackaging, JavaAgent)
   .settings(commonSettings: _*)
   .settings(
-    javaAgents += "com.datadoghq" % "dd-java-agent" % "1.14.0",
+    javaAgents += "com.datadoghq" % "dd-java-agent" % "1.20.0",
     Test / javaOptions += "-Dconfig.file=conf/application.test.conf",
     routesImport += "io.flow.location.v0.Bindables._",
     routesGenerator := InjectedRoutesGenerator,
     libraryDependencies ++= Seq(
-      "io.flow" %% "lib-play-play28" % "0.7.69",
-      "io.flow" %% "lib-metrics-play28" % "1.0.55",
-      "io.flow" %% "lib-reference-scala" % "0.3.22",
-      "io.flow" %% "lib-s3-play28" % "0.3.76",
+      "io.flow" %% "lib-play-play28" % "0.7.75",
+      "io.flow" %% "lib-metrics-play28" % "1.0.62",
+      "io.flow" %% "lib-reference-scala" % "0.3.27",
+      "io.flow" %% "lib-s3-play28" % "0.3.82",
       "com.google.maps" % "google-maps-services" % "2.0.0",
       "io.flow" %% "lib-healthcheck-play28" % "0.0.12",
       "org.scalacheck" %% "scalacheck" % "1.17.0" % "test",
-      "io.flow" %% "lib-test-utils-play28" % "0.2.0" % Test,
-      "io.flow" %% "lib-usage-play28" % "0.2.20",
-      "io.flow" %% "lib-log" % "0.1.94"
+      "io.flow" %% "lib-test-utils-play28" % "0.2.7" % Test,
+      "io.flow" %% "lib-usage-play28" % "0.2.27",
+      "io.flow" %% "lib-log" % "0.1.99"
     ),
   )
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,7 +5,7 @@ logLevel := Level.Warn
 resolvers += "Typesafe repository" at "https://repo.typesafe.com/typesafe/releases/"
 
 // Use the Play sbt plugin for Play projects
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.19")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.20")
 
 addSbtPlugin("com.lightbend.sbt" % "sbt-javaagent" % "0.1.5")
 
@@ -15,7 +15,7 @@ addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.4.1")
 
 resolvers += "Flow Plugins" at "https://flow.jfrog.io/flow/plugins-release/"
 
-addSbtPlugin("io.flow" % "sbt-flow-linter" % "0.0.37")
+addSbtPlugin("io.flow" % "sbt-flow-linter" % "0.0.40")
 
 // Resolve scala-xml version dependency mismatch, see https://github.com/sbt/sbt/issues/7007
 ThisBuild / libraryDependencySchemes ++= Seq(


### PR DESCRIPTION
- com.datadoghq
  - dd-java-agent (1.14.0 => 1.20.0)
- com.typesafe.play
  - sbt-plugin (2.8.19 => 2.8.20)
- io.flow
  - lib-log (0.1.94 => 0.1.99)
  - lib-metrics-play28 (1.0.55 => 1.0.62)
  - lib-play-play28 (0.7.69 => 0.7.75)
  - lib-reference-scala (0.3.22 => 0.3.27)
  - lib-s3-play28 (0.3.76 => 0.3.82)
  - lib-test-utils-play28 (0.2.0 => 0.2.7)
  - lib-usage-play28 (0.2.20 => 0.2.27)
  - sbt-flow-linter (0.0.37 => 0.0.40)