### PR TITLE
Upgrade libraries

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -60,8 +60,8 @@ lazy val commonSettings: Seq[Setting[_]] = Seq(
     "com.google.inject.extensions" % "guice-assistedinject" % "5.1.0",
     "org.projectlombok" % "lombok" % "1.18.28" % "provided",
     ws,
-    "com.typesafe.play" %% "play-json-joda" % "2.10.1",
-    "com.typesafe.play" %% "play-json" % "2.10.1",
+    "com.typesafe.play" %% "play-json-joda" % "2.9.4",
+    "com.typesafe.play" %% "play-json" % "2.9.4",
   ),
   Test / javaOptions ++= Seq(
     "--add-exports=java.base/sun.security.x509=ALL-UNNAMED",

--- a/build.sbt
+++ b/build.sbt
@@ -31,7 +31,7 @@ lazy val api = project
   .enablePlugins(JavaAppPackaging, JavaAgent)
   .settings(commonSettings: _*)
   .settings(
-    javaAgents += "com.datadoghq" % "dd-java-agent" % "1.20.0",
+    javaAgents += "com.datadoghq" % "dd-java-agent" % "1.20.1",
     Test / javaOptions += "-Dconfig.file=conf/application.test.conf",
     Test / javaOptions ++= Seq(
       "--add-exports=java.base/sun.security.x509=ALL-UNNAMED",
@@ -40,16 +40,16 @@ lazy val api = project
     routesImport += "io.flow.location.v0.Bindables._",
     routesGenerator := InjectedRoutesGenerator,
     libraryDependencies ++= Seq(
-      "io.flow" %% "lib-play-play28" % "0.7.75",
-      "io.flow" %% "lib-metrics-play28" % "1.0.62",
-      "io.flow" %% "lib-reference-scala" % "0.3.27",
-      "io.flow" %% "lib-s3-play28" % "0.3.82",
+      "io.flow" %% "lib-play-play28" % "0.7.77",
+      "io.flow" %% "lib-metrics-play28" % "1.0.65",
+      "io.flow" %% "lib-reference-scala" % "0.3.29",
+      "io.flow" %% "lib-s3-play28" % "0.3.84",
       "com.google.maps" % "google-maps-services" % "2.0.0",
       "io.flow" %% "lib-healthcheck-play28" % "0.0.12",
       "org.scalacheck" %% "scalacheck" % "1.17.0" % "test",
-      "io.flow" %% "lib-test-utils-play28" % "0.2.7" % Test,
-      "io.flow" %% "lib-usage-play28" % "0.2.27",
-      "io.flow" %% "lib-log" % "0.1.99"
+      "io.flow" %% "lib-test-utils-play28" % "0.2.11" % Test,
+      "io.flow" %% "lib-usage-play28" % "0.2.29",
+      "io.flow" %% "lib-log" % "0.2.2"
     ),
   )
 
@@ -60,8 +60,8 @@ lazy val commonSettings: Seq[Setting[_]] = Seq(
     "com.google.inject.extensions" % "guice-assistedinject" % "5.1.0",
     "org.projectlombok" % "lombok" % "1.18.28" % "provided",
     ws,
-    "com.typesafe.play" %% "play-json-joda" % "2.9.4",
-    "com.typesafe.play" %% "play-json" % "2.9.4",
+    "com.typesafe.play" %% "play-json-joda" % "2.10.1",
+    "com.typesafe.play" %% "play-json" % "2.10.1",
   ),
   Test / javaOptions ++= Seq(
     "--add-exports=java.base/sun.security.x509=ALL-UNNAMED",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -15,7 +15,7 @@ addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.4.1")
 
 resolvers += "Flow Plugins" at "https://flow.jfrog.io/flow/plugins-release/"
 
-addSbtPlugin("io.flow" % "sbt-flow-linter" % "0.0.40")
+addSbtPlugin("io.flow" % "sbt-flow-linter" % "0.0.41")
 
 // Resolve scala-xml version dependency mismatch, see https://github.com/sbt/sbt/issues/7007
 ThisBuild / libraryDependencySchemes ++= Seq(


### PR DESCRIPTION
- com.datadoghq
  - dd-java-agent (1.20.0 => 1.20.1)
- com.typesafe.play
  - play-json (2.9.4 => 2.10.1)
  - play-json-joda (2.9.4 => 2.10.1)
- io.flow
  - lib-log (0.1.99 => 0.2.2)
  - lib-metrics-play28 (1.0.62 => 1.0.65)
  - lib-play-play28 (0.7.75 => 0.7.77)
  - lib-reference-scala (0.3.27 => 0.3.29)
  - lib-s3-play28 (0.3.82 => 0.3.84)
  - lib-test-utils-play28 (0.2.7 => 0.2.11)
  - lib-usage-play28 (0.2.27 => 0.2.29)
  - sbt-flow-linter (0.0.40 => 0.0.41)