### PR TITLE
Upgrade libraries com.datadoghq, io.flow

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -30,7 +30,7 @@ lazy val api = project
   .enablePlugins(JavaAppPackaging, JavaAgent)
   .settings(commonSettings: _*)
   .settings(
-    javaAgents += "com.datadoghq" % "dd-java-agent" % "1.27.0",
+    javaAgents += "com.datadoghq" % "dd-java-agent" % "1.28.0",
     Test / javaOptions += "-Dconfig.file=conf/application.test.conf",
     Test / javaOptions ++= Seq(
       "--add-exports=java.base/sun.security.x509=ALL-UNNAMED",
@@ -39,16 +39,16 @@ lazy val api = project
     routesImport += "io.flow.location.v0.Bindables._",
     routesGenerator := InjectedRoutesGenerator,
     libraryDependencies ++= Seq(
-      "io.flow" %% "lib-play-play28" % "0.7.87",
-      "io.flow" %% "lib-metrics-play28" % "1.0.76",
-      "io.flow" %% "lib-reference-scala" % "0.3.37",
-      "io.flow" %% "lib-s3-play28" % "0.3.92",
+      "io.flow" %% "lib-play-play28" % "0.7.89",
+      "io.flow" %% "lib-metrics-play28" % "1.0.77",
+      "io.flow" %% "lib-reference-scala" % "0.3.40",
+      "io.flow" %% "lib-s3-play28" % "0.3.93",
       "com.google.maps" % "google-maps-services" % "2.0.0",
-      "io.flow" %% "lib-healthcheck-play28" % "0.0.16",
+      "io.flow" %% "lib-healthcheck-play28" % "0.0.18",
       "org.scalacheck" %% "scalacheck" % "1.17.0" % "test",
-      "io.flow" %% "lib-test-utils-play28" % "0.2.22" % Test,
-      "io.flow" %% "lib-usage-play28" % "0.2.36",
-      "io.flow" %% "lib-log" % "0.2.12",
+      "io.flow" %% "lib-test-utils-play28" % "0.2.23" % Test,
+      "io.flow" %% "lib-usage-play28" % "0.2.37",
+      "io.flow" %% "lib-log" % "0.2.14",
     ),
   )
 


### PR DESCRIPTION
- com.datadoghq
  - dd-java-agent (1.27.0 => 1.28.0)
- io.flow
  - lib-healthcheck-play28 (0.0.16 => 0.0.18)
  - lib-log (0.2.12 => 0.2.14)
  - lib-metrics-play28 (1.0.76 => 1.0.77)
  - lib-play-play28 (0.7.87 => 0.7.89)
  - lib-reference-scala (0.3.37 => 0.3.40)
  - lib-s3-play28 (0.3.92 => 0.3.93)
  - lib-test-utils-play28 (0.2.22 => 0.2.23)
  - lib-usage-play28 (0.2.36 => 0.2.37)