### PR TITLE
LOG-1825: Upgrade libraries com.datadoghq, io.flow

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -30,7 +30,7 @@ lazy val api = project
   .enablePlugins(JavaAppPackaging, JavaAgent)
   .settings(commonSettings: _*)
   .settings(
-    javaAgents += "com.datadoghq" % "dd-java-agent" % "1.28.0",
+    javaAgents += "com.datadoghq" % "dd-java-agent" % "1.31.2",
     Test / javaOptions += "-Dconfig.file=conf/application.test.conf",
     Test / javaOptions ++= Seq(
       "--add-exports=java.base/sun.security.x509=ALL-UNNAMED",
@@ -39,16 +39,16 @@ lazy val api = project
     routesImport += "io.flow.location.v0.Bindables._",
     routesGenerator := InjectedRoutesGenerator,
     libraryDependencies ++= Seq(
-      "io.flow" %% "lib-play-play28" % "0.7.90",
-      "io.flow" %% "lib-metrics-play28" % "1.0.79",
-      "io.flow" %% "lib-reference-scala" % "0.3.40",
-      "io.flow" %% "lib-s3-play28" % "0.3.94",
+      "io.flow" %% "lib-play-play28" % "0.7.96",
+      "io.flow" %% "lib-metrics-play28" % "1.0.83",
+      "io.flow" %% "lib-reference-scala" % "0.3.41",
+      "io.flow" %% "lib-s3-play28" % "0.3.98",
       "com.google.maps" % "google-maps-services" % "2.0.0",
-      "io.flow" %% "lib-healthcheck-play28" % "0.0.20",
+      "io.flow" %% "lib-healthcheck-play28" % "0.0.23",
       "org.scalacheck" %% "scalacheck" % "1.17.0" % "test",
-      "io.flow" %% "lib-test-utils-play28" % "0.2.24" % Test,
-      "io.flow" %% "lib-usage-play28" % "0.2.38",
-      "io.flow" %% "lib-log" % "0.2.14",
+      "io.flow" %% "lib-test-utils-play28" % "0.2.27" % Test,
+      "io.flow" %% "lib-usage-play28" % "0.2.41",
+      "io.flow" %% "lib-log" % "0.2.15",
     ),
   )
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -13,7 +13,7 @@ addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.4.1")
 
 resolvers += "Flow Plugins" at "https://flow.jfrog.io/flow/plugins-release/"
 
-addSbtPlugin("io.flow" % "sbt-flow-linter" % "0.0.54")
+addSbtPlugin("io.flow" % "sbt-flow-linter" % "0.0.55")
 
 // Resolve scala-xml version dependency mismatch, see https://github.com/sbt/sbt/issues/7007
 ThisBuild / libraryDependencySchemes ++= Seq(


### PR DESCRIPTION
- com.datadoghq
  - dd-java-agent (1.28.0 => 1.31.2)
- io.flow
  - lib-healthcheck-play28 (0.0.20 => 0.0.23)
  - lib-log (0.2.14 => 0.2.15)
  - lib-metrics-play28 (1.0.79 => 1.0.83)
  - lib-play-play28 (0.7.90 => 0.7.96)
  - lib-reference-scala (0.3.40 => 0.3.41)
  - lib-s3-play28 (0.3.94 => 0.3.98)
  - lib-test-utils-play28 (0.2.24 => 0.2.27)
  - lib-usage-play28 (0.2.38 => 0.2.41)
  - sbt-flow-linter (0.0.54 => 0.0.55)