### PR TITLE
FDN-2303: Upgrade libraries

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -30,7 +30,7 @@ lazy val api = project
   .enablePlugins(JavaAppPackaging, JavaAgent)
   .settings(commonSettings: _*)
   .settings(
-    javaAgents += "com.datadoghq" % "dd-java-agent" % "1.32.0",
+    javaAgents += "com.datadoghq" % "dd-java-agent" % "1.33.0",
     Test / javaOptions += "-Dconfig.file=conf/application.test.conf",
     Test / javaOptions ++= Seq(
       "--add-exports=java.base/sun.security.x509=ALL-UNNAMED",
@@ -39,16 +39,16 @@ lazy val api = project
     routesImport += "io.flow.location.v0.Bindables._",
     routesGenerator := InjectedRoutesGenerator,
     libraryDependencies ++= Seq(
-      "io.flow" %% "lib-play-play28" % "0.7.98",
-      "io.flow" %% "lib-metrics-play28" % "1.0.85",
+      "io.flow" %% "lib-play-play28" % "0.7.99",
+      "io.flow" %% "lib-metrics-play28" % "1.0.86",
       "io.flow" %% "lib-reference-scala" % "0.3.43",
-      "io.flow" %% "lib-s3-play28" % "0.4.0",
+      "io.flow" %% "lib-s3-play28" % "0.4.1",
       "com.google.maps" % "google-maps-services" % "2.0.0",
-      "io.flow" %% "lib-healthcheck-play28" % "0.0.25",
-      "org.scalacheck" %% "scalacheck" % "1.17.0" % "test",
-      "io.flow" %% "lib-test-utils-play28" % "0.2.29" % Test,
-      "io.flow" %% "lib-usage-play28" % "0.2.44",
-      "io.flow" %% "lib-log" % "0.2.17",
+      "io.flow" %% "lib-healthcheck-play28" % "0.0.26",
+      "org.scalacheck" %% "scalacheck" % "1.18.0" % "test",
+      "io.flow" %% "lib-test-utils-play28" % "0.2.30" % Test,
+      "io.flow" %% "lib-usage-play28" % "0.2.45",
+      "io.flow" %% "lib-log" % "0.2.18",
     ),
   )
 


### PR DESCRIPTION
- com.datadoghq
  - dd-java-agent (1.32.0 => 1.33.0)
- io.flow
  - lib-healthcheck-play28 (0.0.25 => 0.0.26)
  - lib-log (0.2.17 => 0.2.18)
  - lib-metrics-play28 (1.0.85 => 1.0.86)
  - lib-play-play28 (0.7.98 => 0.7.99)
  - lib-s3-play28 (0.4.0 => 0.4.1)
  - lib-test-utils-play28 (0.2.29 => 0.2.30)
  - lib-usage-play28 (0.2.44 => 0.2.45)
- org.scalacheck
  - scalacheck (1.17.0 => 1.18.0)