### PR TITLE
FDN-2371: Upgrade libraries com.datadoghq, io.flow

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -36,7 +36,7 @@ lazy val api = project
   .enablePlugins(JavaAppPackaging, JavaAgent)
   .settings(commonSettings: _*)
   .settings(
-    javaAgents += "com.datadoghq" % "dd-java-agent" % "1.33.0",
+    javaAgents += "com.datadoghq" % "dd-java-agent" % "1.34.0",
     Test / javaOptions += "-Dconfig.file=conf/application.test.conf",
     Test / javaOptions ++= Seq(
       "--add-exports=java.base/sun.security.x509=ALL-UNNAMED",
@@ -45,16 +45,16 @@ lazy val api = project
     routesImport += "io.flow.location.v0.Bindables._",
     routesGenerator := InjectedRoutesGenerator,
     libraryDependencies ++= Seq(
-      "io.flow" %% "lib-play-play28" % "0.8.0",
-      "io.flow" %% "lib-metrics-play28" % "1.0.87",
-      "io.flow" %% "lib-reference-scala" % "0.3.44",
-      "io.flow" %% "lib-s3-play28" % "0.4.2",
+      "io.flow" %% "lib-play-play28" % "0.8.2",
+      "io.flow" %% "lib-metrics-play28" % "1.0.89",
+      "io.flow" %% "lib-reference-scala" % "0.3.46",
+      "io.flow" %% "lib-s3-play28" % "0.4.4",
       "com.google.maps" % "google-maps-services" % "2.0.0",
-      "io.flow" %% "lib-healthcheck-play28" % "0.0.27",
+      "io.flow" %% "lib-healthcheck-play28" % "0.0.30",
       "org.scalacheck" %% "scalacheck" % "1.18.0" % "test",
-      "io.flow" %% "lib-test-utils-play28" % "0.2.31" % Test,
-      "io.flow" %% "lib-usage-play28" % "0.2.46",
-      "io.flow" %% "lib-log" % "0.2.19",
+      "io.flow" %% "lib-test-utils-play28" % "0.2.32" % Test,
+      "io.flow" %% "lib-usage-play28" % "0.2.49",
+      "io.flow" %% "lib-log" % "0.2.21",
     ),
   )
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -13,7 +13,7 @@ addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.4.1")
 
 resolvers += "Flow Plugins" at "https://flow.jfrog.io/flow/plugins-release/"
 
-addSbtPlugin("io.flow" % "sbt-flow-linter" % "0.0.55")
+addSbtPlugin("io.flow" % "sbt-flow-linter" % "0.0.56")
 
 // Resolve scala-xml version dependency mismatch, see https://github.com/sbt/sbt/issues/7007
 ThisBuild / libraryDependencySchemes ++= Seq(


### PR DESCRIPTION
- com.datadoghq
  - dd-java-agent (1.33.0 => 1.34.0)
- io.flow
  - lib-healthcheck-play28 (0.0.27 => 0.0.30)
  - lib-log (0.2.19 => 0.2.21)
  - lib-metrics-play28 (1.0.87 => 1.0.89)
  - lib-play-play28 (0.8.0 => 0.8.2)
  - lib-reference-scala (0.3.44 => 0.3.46)
  - lib-s3-play28 (0.4.2 => 0.4.4)
  - lib-test-utils-play28 (0.2.31 => 0.2.32)
  - lib-usage-play28 (0.2.46 => 0.2.49)
  - sbt-flow-linter (0.0.55 => 0.0.56)