### PR TITLE
FDN-2397:upgrade scala v2.13.13 and sbt version upgrade & Scoverage

### DIFF
--- a/api/app/controllers/Addresses.scala
+++ b/api/app/controllers/Addresses.scala
@@ -19,7 +19,7 @@ class Addresses @javax.inject.Inject() (
   helpers: Helpers,
   system: ActorSystem,
 ) extends BaseController {
-  private[this] implicit val ec = system.dispatchers.lookup("controller-context")
+  private[this] implicit val ec: akka.dispatch.MessageDispatcher = system.dispatchers.lookup("controller-context")
 
   def get(
     address: Option[String],

--- a/api/app/controllers/CountryDefaults.scala
+++ b/api/app/controllers/CountryDefaults.scala
@@ -16,7 +16,7 @@ class CountryDefaults @javax.inject.Inject() (
   helpers: Helpers,
   system: ActorSystem,
 ) extends BaseController {
-  private[this] implicit val ec = system.dispatchers.lookup("controller-context")
+  private[this] implicit val ec: akka.dispatch.MessageDispatcher = system.dispatchers.lookup("controller-context")
   private[this] val DefaultCurrency = "usd" // Remove once every country has one defined
   private[this] val DefaultLanguage = "en" // Remove once every country has at least one language in reference data
 

--- a/api/app/controllers/Healthchecks.scala
+++ b/api/app/controllers/Healthchecks.scala
@@ -13,7 +13,7 @@ class Healthchecks @javax.inject.Inject() (
   addresses: Addresses,
   system: ActorSystem,
 ) extends BaseController {
-  private[this] implicit val ec = system.dispatchers.lookup("controller-context")
+  private[this] implicit val ec: akka.dispatch.MessageDispatcher = system.dispatchers.lookup("controller-context")
 
   def getHealthcheck() = Action.async { request =>
     // force loading of config

--- a/api/app/controllers/Timezones.scala
+++ b/api/app/controllers/Timezones.scala
@@ -17,7 +17,7 @@ class Timezones @javax.inject.Inject() (
   helpers: Helpers,
   system: ActorSystem,
 ) extends BaseController {
-  private[this] implicit val ec = system.dispatchers.lookup("controller-context")
+  private[this] implicit val ec: akka.dispatch.MessageDispatcher = system.dispatchers.lookup("controller-context")
 
   def get(
     ip: Option[String],

--- a/api/test/utils/CollectionsSpec.scala
+++ b/api/test/utils/CollectionsSpec.scala
@@ -13,7 +13,7 @@ case class SearchWithBoundaryFixture(elems: IndexedSeq[Long], boundary: Long)
 
 object SearchWithBoundaryProperties extends Properties("SearchWithBoundaries") {
 
-  implicit def buildableIndexedSeq[T: Ordering] = new Buildable[T, IndexedSeq[T]] {
+  implicit def buildableIndexedSeq[T: Ordering]: Buildable[T, IndexedSeq[T]] = new Buildable[T, IndexedSeq[T]] {
     def builder = new mutable.Builder[T, IndexedSeq[T]] {
       val ab = new ArrayBuffer[T]()
       override def addOne(x: T) = {

--- a/api/test/utils/DigitalElementSpec.scala
+++ b/api/test/utils/DigitalElementSpec.scala
@@ -5,7 +5,7 @@ import io.flow.location.v0.models.{LocationError, LocationErrorCode}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import utils.DigitalElement.ValidatedIpAddress
-
+import scala.collection.mutable.ArrayBuffer
 class DigitalElementSpec extends AnyWordSpec with Matchers {
 
   // convenience to build DigitalElementIndexRecord fixtures with defaults
@@ -19,14 +19,14 @@ class DigitalElementSpec extends AnyWordSpec with Matchers {
     longitude: Double = 0.0,
     postalCode: String = "",
     fieldDelimiter: Char = ';',
-  ) = DigitalElementIndexRecord(
-    rangeStart = rangeStart,
-    rangeEnd = rangeEnd,
-    fieldDelimiter = fieldDelimiter,
-    bytes = Seq(rangeStart, rangeEnd, country, region, city, latitude, longitude, postalCode)
-      .mkString(fieldDelimiter.toString)
-      .getBytes(),
-  )
+  ): DigitalElementIndexRecord = {
+    val bytes: Array[Byte] =
+      ArrayBuffer[Serializable](rangeStart, rangeEnd, country, region, city, latitude, longitude, postalCode)
+        .map(_.toString)
+        .mkString(fieldDelimiter.toString)
+        .getBytes()
+    DigitalElementIndexRecord(rangeStart, rangeEnd, fieldDelimiter, bytes)
+  }
 
   "validateIp" should {
     "ignore empty IP" in {

--- a/api/test/utils/DigitalElementSpec.scala
+++ b/api/test/utils/DigitalElementSpec.scala
@@ -5,7 +5,7 @@ import io.flow.location.v0.models.{LocationError, LocationErrorCode}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import utils.DigitalElement.ValidatedIpAddress
-import scala.collection.mutable.ArrayBuffer
+
 class DigitalElementSpec extends AnyWordSpec with Matchers {
 
   // convenience to build DigitalElementIndexRecord fixtures with defaults
@@ -19,14 +19,23 @@ class DigitalElementSpec extends AnyWordSpec with Matchers {
     longitude: Double = 0.0,
     postalCode: String = "",
     fieldDelimiter: Char = ';',
-  ): DigitalElementIndexRecord = {
-    val bytes: Array[Byte] =
-      ArrayBuffer[Serializable](rangeStart, rangeEnd, country, region, city, latitude, longitude, postalCode)
-        .map(_.toString)
-        .mkString(fieldDelimiter.toString)
-        .getBytes()
-    DigitalElementIndexRecord(rangeStart, rangeEnd, fieldDelimiter, bytes)
-  }
+  ) = DigitalElementIndexRecord(
+    rangeStart = rangeStart,
+    rangeEnd = rangeEnd,
+    fieldDelimiter = fieldDelimiter,
+    bytes = Seq(
+      rangeStart.toString,
+      rangeEnd.toString,
+      country,
+      region,
+      city,
+      latitude.toString,
+      longitude.toString,
+      postalCode,
+    )
+      .mkString(fieldDelimiter.toString)
+      .getBytes(),
+  )
 
   "validateIp" should {
     "ignore empty IP" in {

--- a/build.sbt
+++ b/build.sbt
@@ -2,12 +2,13 @@ import play.sbt.PlayScala._
 
 name := "location"
 
-ThisBuild / scalaVersion := "2.13.6"
+ThisBuild / scalaVersion := "2.13.13"
 ThisBuild / javacOptions ++= Seq("-source", "17", "-target", "17")
 
 // Resolve scala-xml version dependency mismatch, see https://github.com/sbt/sbt/issues/7007
 ThisBuild / libraryDependencySchemes ++= Seq(
   "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always,
+  "org.scoverage" %% "sbt-scoverage" % VersionScheme.Always,
 )
 
 lazy val allScalacOptions = Seq(

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.9
+sbt.version=1.10.0

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -21,4 +21,4 @@ ThisBuild / libraryDependencySchemes ++= Seq(
 )
 
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.0.8")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.0.11")


### PR DESCRIPTION
In this PR we are upgrading scala version 2.13.13 and sbt as well as scoverage upgrade. For this we have to add type annotation in mentioned files:

 api/app/controllers/Addresses.scala
 api/app/controllers/CountryDefaults.scala
 api/app/controllers/Healthchecks.scala
 api/app/controllers/Timezones.scala
 api/test/utils/CollectionsSpec.scala
 api/test/utils/DigitalElementSpec.scala

