### PR TITLE
PAY-4070: Upgrade libraries

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -37,7 +37,7 @@ lazy val api = project
   .enablePlugins(JavaAppPackaging, JavaAgent)
   .settings(commonSettings: _*)
   .settings(
-    javaAgents += "com.datadoghq" % "dd-java-agent" % "1.39.0",
+    javaAgents += "com.datadoghq" % "dd-java-agent" % "1.40.1",
     Test / javaOptions += "-Dconfig.file=conf/application.test.conf",
     Test / javaOptions ++= Seq(
       "--add-exports=java.base/sun.security.x509=ALL-UNNAMED",
@@ -46,16 +46,16 @@ lazy val api = project
     routesImport += "io.flow.location.v0.Bindables._",
     routesGenerator := InjectedRoutesGenerator,
     libraryDependencies ++= Seq(
-      "io.flow" %% "lib-play-play28" % "0.8.5",
-      "io.flow" %% "lib-metrics-play28" % "1.0.96",
-      "io.flow" %% "lib-reference-scala" % "0.3.53",
-      "io.flow" %% "lib-s3-play28" % "0.4.11",
+      "io.flow" %% "lib-play-play28" % "0.8.6",
+      "io.flow" %% "lib-metrics-play28" % "1.0.97",
+      "io.flow" %% "lib-reference-scala" % "0.3.56",
+      "io.flow" %% "lib-s3-play28" % "0.4.12",
       "com.google.maps" % "google-maps-services" % "2.0.0",
       "io.flow" %% "lib-healthcheck-play28" % "0.0.32",
       "org.scalacheck" %% "scalacheck" % "1.18.1" % "test",
-      "io.flow" %% "lib-test-utils-play28" % "0.2.39" % Test,
-      "io.flow" %% "lib-usage-play28" % "0.2.56",
-      "io.flow" %% "lib-log" % "0.2.25",
+      "io.flow" %% "lib-test-utils-play28" % "0.2.40" % Test,
+      "io.flow" %% "lib-usage-play28" % "0.2.57",
+      "io.flow" %% "lib-log" % "0.2.26",
     ),
   )
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -21,4 +21,4 @@ ThisBuild / libraryDependencySchemes ++= Seq(
 )
 
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.1.0")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.2.1")


### PR DESCRIPTION
- com.datadoghq
  - dd-java-agent (1.39.0 => 1.40.1)
- io.flow
  - lib-log (0.2.25 => 0.2.26)
  - lib-metrics-play28 (1.0.96 => 1.0.97)
  - lib-play-play28 (0.8.5 => 0.8.6)
  - lib-reference-scala (0.3.53 => 0.3.56)
  - lib-s3-play28 (0.4.11 => 0.4.12)
  - lib-test-utils-play28 (0.2.39 => 0.2.40)
  - lib-usage-play28 (0.2.56 => 0.2.57)
- org.scoverage
  - sbt-scoverage (2.1.0 => 2.2.1)