### PR TITLE
FDN-2872:Migration of Location service to karpenter node pools

### DIFF
--- a/deploy/location/values.yaml
+++ b/deploy/location/values.yaml
@@ -14,9 +14,9 @@ image:
 
 resources:
   limits:
-    memory: "5632Mi"
+    memory: "7100Mi"
   requests:
-    memory: "5632Mi"
+    memory: "7100Mi"
     cpu: 1
 
 jvmOpts:

--- a/deploy/location/values.yaml
+++ b/deploy/location/values.yaml
@@ -15,9 +15,10 @@ image:
 resources:
   limits:
     memory: "7100Mi"
+    cpu: 2
   requests:
     memory: "7100Mi"
-    cpu: 1
+    cpu: 500m
 
 jvmOpts:
     memory: 6100m

--- a/deploy/location/values.yaml
+++ b/deploy/location/values.yaml
@@ -14,13 +14,23 @@ image:
 
 resources:
   limits:
-    memory: "7100Mi"
+    memory: "5632Mi"
   requests:
-    memory: "7100Mi"
+    memory: "5632Mi"
     cpu: 1
 
 jvmOpts:
     memory: 6100m
+
+nodeSelector:
+  karpenter/role: workers
+tolerations:
+  - key: "role"
+    operator: "Equal"
+    value: "workers"
+    effect: "NoSchedule"
+topologySpreadConstraints:
+  schedule: "DoNotSchedule"
 
 deployments:
   live:


### PR DESCRIPTION
This PR is raised for migration of Location service to karpenter node pools.
I have adjusted the memory requirement to 5.5Gi from 7 Gi, as we can see in the snapshot below; it is not going beyond 5Gi.

![image](https://github.com/user-attachments/assets/79c32901-2c15-4ec0-867d-7bab19b013dd)
![image](https://github.com/user-attachments/assets/18000c57-b7ce-4e70-8e70-cdce3e9d78e1)
![image](https://github.com/user-attachments/assets/3037f009-6ff3-4e9c-9084-803a3da65880)

