### PR TITLE
FDN-3000: Upgrade libraries

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -37,7 +37,7 @@ lazy val api = project
   .enablePlugins(JavaAppPackaging, JavaAgent)
   .settings(commonSettings: _*)
   .settings(
-    javaAgents += "com.datadoghq" % "dd-java-agent" % "1.40.1",
+    javaAgents += "com.datadoghq" % "dd-java-agent" % "1.42.1",
     Test / javaOptions += "-Dconfig.file=conf/application.test.conf",
     Test / javaOptions ++= Seq(
       "--add-exports=java.base/sun.security.x509=ALL-UNNAMED",
@@ -46,16 +46,16 @@ lazy val api = project
     routesImport += "io.flow.location.v0.Bindables._",
     routesGenerator := InjectedRoutesGenerator,
     libraryDependencies ++= Seq(
-      "io.flow" %% "lib-play-play28" % "0.8.7",
-      "io.flow" %% "lib-metrics-play28" % "1.0.97",
-      "io.flow" %% "lib-reference-scala" % "0.3.56",
-      "io.flow" %% "lib-s3-play28" % "0.4.13",
+      "io.flow" %% "lib-play-play28" % "0.8.8",
+      "io.flow" %% "lib-metrics-play28" % "1.1.1",
+      "io.flow" %% "lib-reference-scala" % "0.3.57",
+      "io.flow" %% "lib-s3-play28" % "0.4.14",
       "com.google.maps" % "google-maps-services" % "2.0.0",
       "io.flow" %% "lib-healthcheck-play28" % "0.0.32",
       "org.scalacheck" %% "scalacheck" % "1.18.1" % "test",
-      "io.flow" %% "lib-test-utils-play28" % "0.2.40" % Test,
-      "io.flow" %% "lib-usage-play28" % "0.2.58",
-      "io.flow" %% "lib-log" % "0.2.27",
+      "io.flow" %% "lib-test-utils-play28" % "0.2.41" % Test,
+      "io.flow" %% "lib-usage-play28" % "0.2.59",
+      "io.flow" %% "lib-log" % "0.2.28",
     ),
   )
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -13,7 +13,7 @@ addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.4.1")
 
 resolvers += "Flow Plugins" at "https://flow.jfrog.io/flow/plugins-release/"
 
-addSbtPlugin("io.flow" % "sbt-flow-linter" % "0.0.57")
+addSbtPlugin("io.flow" % "sbt-flow-linter" % "0.0.59")
 
 // Resolve scala-xml version dependency mismatch, see https://github.com/sbt/sbt/issues/7007
 ThisBuild / libraryDependencySchemes ++= Seq(
@@ -21,4 +21,4 @@ ThisBuild / libraryDependencySchemes ++= Seq(
 )
 
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.2.1")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.2.2")


### PR DESCRIPTION
- com.datadoghq
  - dd-java-agent (1.40.1 => 1.42.1)
- io.flow
  - lib-log (0.2.27 => 0.2.28)
  - lib-metrics-play28 (1.0.97 => 1.1.1)
  - lib-play-play28 (0.8.7 => 0.8.8)
  - lib-reference-scala (0.3.56 => 0.3.57)
  - lib-s3-play28 (0.4.13 => 0.4.14)
  - lib-test-utils-play28 (0.2.40 => 0.2.41)
  - lib-usage-play28 (0.2.58 => 0.2.59)
  - sbt-flow-linter (0.0.57 => 0.0.59)
- org.scoverage
  - sbt-scoverage (2.2.1 => 2.2.2)