### PR TITLE
FDN-3092: Upgrade libraries com.datadoghq, io.flow

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -37,7 +37,7 @@ lazy val api = project
   .enablePlugins(JavaAppPackaging, JavaAgent)
   .settings(commonSettings: _*)
   .settings(
-    javaAgents += "com.datadoghq" % "dd-java-agent" % "1.42.2",
+    javaAgents += "com.datadoghq" % "dd-java-agent" % "1.43.0",
     Test / javaOptions += "-Dconfig.file=conf/application.test.conf",
     Test / javaOptions ++= Seq(
       "--add-exports=java.base/sun.security.x509=ALL-UNNAMED",
@@ -47,14 +47,14 @@ lazy val api = project
     routesGenerator := InjectedRoutesGenerator,
     libraryDependencies ++= Seq(
       "io.flow" %% "lib-play-play28" % "0.8.8",
-      "io.flow" %% "lib-metrics-play28" % "1.1.1",
+      "io.flow" %% "lib-metrics-play28" % "1.1.2",
       "io.flow" %% "lib-reference-scala" % "0.3.57",
-      "io.flow" %% "lib-s3-play28" % "0.4.14",
+      "io.flow" %% "lib-s3-play28" % "0.4.15",
       "com.google.maps" % "google-maps-services" % "2.0.0",
       "io.flow" %% "lib-healthcheck-play28" % "0.0.32",
       "org.scalacheck" %% "scalacheck" % "1.18.1" % "test",
-      "io.flow" %% "lib-test-utils-play28" % "0.2.41" % Test,
-      "io.flow" %% "lib-usage-play28" % "0.2.60",
+      "io.flow" %% "lib-test-utils-play28" % "0.2.42" % Test,
+      "io.flow" %% "lib-usage-play28" % "0.2.62",
       "io.flow" %% "lib-log" % "0.2.28",
     ),
   )


### PR DESCRIPTION
- com.datadoghq
  - dd-java-agent (1.42.2 => 1.43.0)
- io.flow
  - lib-metrics-play28 (1.1.1 => 1.1.2)
  - lib-s3-play28 (0.4.14 => 0.4.15)
  - lib-test-utils-play28 (0.2.41 => 0.2.42)
  - lib-usage-play28 (0.2.60 => 0.2.62)