### PR TITLE
COR-2398: Upgrade libraries

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -37,7 +37,7 @@ lazy val api = project
   .enablePlugins(JavaAppPackaging, JavaAgent)
   .settings(commonSettings: _*)
   .settings(
-    javaAgents += "com.datadoghq" % "dd-java-agent" % "1.44.1",
+    javaAgents += "com.datadoghq" % "dd-java-agent" % "1.45.2",
     Test / javaOptions += "-Dconfig.file=conf/application.test.conf",
     Test / javaOptions ++= Seq(
       "--add-exports=java.base/sun.security.x509=ALL-UNNAMED",
@@ -54,8 +54,8 @@ lazy val api = project
       "io.flow" %% "lib-healthcheck-play28" % "0.0.33",
       "org.scalacheck" %% "scalacheck" % "1.18.1" % "test",
       "io.flow" %% "lib-test-utils-play28" % "0.2.43" % Test,
-      "io.flow" %% "lib-usage-play28" % "0.2.64",
-      "io.flow" %% "lib-log" % "0.2.29",
+      "io.flow" %% "lib-usage-play28" % "0.2.65",
+      "io.flow" %% "lib-log" % "0.2.30",
     ),
   )
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -13,12 +13,12 @@ addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.4.1")
 
 resolvers += "Flow Plugins" at "https://flow.jfrog.io/flow/plugins-release/"
 
-addSbtPlugin("io.flow" % "sbt-flow-linter" % "0.0.59")
+addSbtPlugin("io.flow" % "sbt-flow-linter" % "0.0.60")
 
 // Resolve scala-xml version dependency mismatch, see https://github.com/sbt/sbt/issues/7007
 ThisBuild / libraryDependencySchemes ++= Seq(
   "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always,
 )
 
-addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.2.2")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.4")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.3.0")


### PR DESCRIPTION
- com.datadoghq
  - dd-java-agent (1.44.1 => 1.45.2)
- io.flow
  - lib-log (0.2.29 => 0.2.30)
  - lib-usage-play28 (0.2.64 => 0.2.65)
  - sbt-flow-linter (0.0.59 => 0.0.60)
- org.scalameta
  - sbt-scalafmt (2.5.2 => 2.5.4)
- org.scoverage
  - sbt-scoverage (2.2.2 => 2.3.0)