### PR TITLE
FDN-3307 Wind back one version of postgresql driver lib

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -46,7 +46,7 @@ lazy val api = project
     routesImport += "io.flow.location.v0.Bindables._",
     routesGenerator := InjectedRoutesGenerator,
     libraryDependencies ++= Seq(
-      "io.flow" %% "lib-play-play29" % "0.8.10",
+      "io.flow" %% "lib-play-play29" % "0.8.11",
       "io.flow" %% "lib-metrics-play29" % "1.1.6",
       "io.flow" %% "lib-reference-scala" % "0.3.57",
       "io.flow" %% "lib-s3-play29" % "0.4.19",


### PR DESCRIPTION

Due to an issue [[here](https://github.com/pgjdbc/pgjdbc/issues/3508)] with version 42.7.5 of the postgresql driver lib, we need to revert back to 42.7.4.

The issue is that the `ApplicationName` parameter on the db url gets lost when `assumeMinServerVersion` is set.

<sub>This PR was generated using [turbolift](https://github.com/Skyscanner/turbolift).</sub>