### PR TITLE
FDN-3458 Update library versions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -47,7 +47,7 @@ lazy val api = project
     routesGenerator := InjectedRoutesGenerator,
     libraryDependencies ++= Seq(
       "io.flow" %% "lib-play-play29" % "0.8.15",
-      "io.flow" %% "lib-metrics-play29" % "1.1.10",
+      "io.flow" %% "lib-metrics-play29" % "1.1.12",
       "io.flow" %% "lib-reference-scala" % "0.3.62",
       "io.flow" %% "lib-s3-play29" % "0.4.25",
       "com.google.maps" % "google-maps-services" % "2.0.0",


### PR DESCRIPTION

Consume latest version of the following libraries:

* `lib-metrics` to obtain fix for case where DatadogMetricsSystem sometimes fails to initialize.
* `lib-postgresql-play` to get per-table logging of output from `ReplicatedTableCountsActor`, plus guaranteed push of metrics when published.

<sub>This PR was generated using [turbolift](https://github.com/Skyscanner/turbolift).</sub>