### PR TITLE
FDN-3587 set Pod Disruption Budget not 0

### DIFF
--- a/deploy/location/values.yaml
+++ b/deploy/location/values.yaml
@@ -36,7 +36,7 @@ deployments:
   live:
     minReplicas: 2
     maxReplicas: 3
-    maxUnavailable: 0
+    maxUnavailable: 1
     averageUtilization: 70
     autoscaleEnabled: true
     AWSRole: "arn:aws:iam::479720515435:role/flow-prod-eks-production-role"


### PR DESCRIPTION
when PodDisruptionBudget set 0 it could cause issue when pod is scheduled on a spot instance, Spot instance is not static environment and could get reclaim, during reclaim - Karpenter has 2-3 minutes to find another node for an affected pods and k8s/deployment with PodDisruptionBudget 0 blocks migration pod and forcely terminate pod because node is terminated by AWS. 

```
Found orphaned Pod assigned to the Node, deleting" logger="pod-garbage-collector-controller" pod="production/location-live-65797f75fb-kp6g9" node="ip-10-143-242-26.ec2.internal
```

```
"Cannot evict pod as it would violate the pod's disruption budget.",
```

```
"The disruption budget location-live needs 2 healthy pods and has 2 currently"
```
